### PR TITLE
Undo making suppliedItem element mandatory

### DIFF
--- a/input/fsh/resources/SupplyDelivery.fsh
+++ b/input/fsh/resources/SupplyDelivery.fsh
@@ -5,6 +5,7 @@ Description: "SupplyDelivery profile for EAHP Interoperability SIG."
 
 * identifier MS
 * basedOn MS
+* suppliedItem 1..*
 * suppliedItem.item[x] only Reference(InventoryItem)
 * supplier MS
 * destination MS


### PR DESCRIPTION
I think that the suppliedItem element in the SupplyDelivery resource should not have a cardinality of 1..n, but 0..n.

As long as status is not ‘completed’, there may not be a suppliedItem. Maybe parties should be able to register a supplyDelivery resource while there is no suppliedItem yet? Maybe as a confirmation to the requester that the SupplyRequest is seen and its processing is started? 

For the requester, a Subscription to (changes in) SupplyDelivery resources that reference a SupplyRequest could be very useful to track progress, especially when delivery is not completed yet. Or is a different resource/mechanism expected to be used for tracking progress of an anticipated delivery?