### PR TITLE
Relax suppliedItem cardinality to support in-progress deliveries

### DIFF
--- a/input/fsh/resources/SupplyDelivery.fsh
+++ b/input/fsh/resources/SupplyDelivery.fsh
@@ -5,7 +5,6 @@ Description: "SupplyDelivery profile for EAHP Interoperability SIG."
 
 * identifier MS
 * basedOn MS
-* suppliedItem 1..*
 * suppliedItem.item[x] only Reference(InventoryItem)
 * suppliedItem.item[x] ^type.aggregation = #contained
 * suppliedItem.quantity MS


### PR DESCRIPTION
Removes the `1..*` constraint on `suppliedItem` in the SupplyDelivery profile.

Previously, this element was mandatory. However, in workflows where a delivery is still in progress or empty, the specific items delivered may not yet be known. Reverting to the base cardinality (0..*) allows the resource to be validated in these scenarios.